### PR TITLE
Warning-free redefinition of PIDFILE for downstreams

### DIFF
--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -38,7 +38,9 @@
 #define MDNS_ADDR "224.0.0.251"
 #define MDNS_PORT 5353
 
+#ifndef PIDFILE
 #define PIDFILE "/var/run/" PACKAGE ".pid"
+#endif
 
 #define MAX_SOCKS 16
 #define MAX_SUBNETS 16


### PR DESCRIPTION
Modern Linux distributions prefer to have the PID file of a service in `/run/` or `/run/mdns-repeater/`, however using `-DPIDFILE="\"…\""` leads to a redefinition warning by the compiler.