### PR TITLE
Fix compiler warning about unused chdir() result

### DIFF
--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -296,7 +296,10 @@ static void daemonize() {
 
 	setsid();
 	umask(0027);
-	chdir("/");
+	if (chdir("/") < 0) {
+		log_message(LOG_ERR, "unable to change to root directory");
+		exit(1);
+	}
 
 	// close all std fd and reopen /dev/null for them
 	int i;


### PR DESCRIPTION
GCC warns about ignoring the chdir() return value. If the directory change is meaningful, we should probably also react if it fails.