### PR TITLE
Add IPv6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+_hgversion
+mdns-repeater
+mdns-repeater-*.zip

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CFLAGS+= -DHGVERSION="\"${HGVERSION}\""
 
 all: mdns-repeater
 
-mdns-repeater.o: _hgversion
+mdns-repeater.o: _hgversion list.h
 
 mdns-repeater: mdns-repeater.o
 

--- a/README.txt
+++ b/README.txt
@@ -1,17 +1,21 @@
 mdns-repeater
 ==============
 mdns-repeater is a Multicast DNS repeater for Linux. Multicast DNS uses the 
-224.0.0.251 address, which is "administratively scoped" and does not 
-leave the subnet.
+224.0.0.251 (IPv4) and ff02::fb (IPv6) addresses, which are "administratively
+scoped" and do not leave the subnet.
 
 This program re-broadcast mDNS packets from one interface to other interfaces.
 It was written primarily to be run on my Linksys WRT54G which runs dd-wrt,
 since my wireless network is on a different subnet from my wired network and 
 I would like my zeroconf devices to work properly across the two subnets.
 
-Since the mDNS protocol sends the AA records in the packet itself, the 
+Since the mDNS protocol sends the A records in the packet itself, the
 repeater does not need to forge the source address. Instead, the source 
 address is of the interface that repeats the packet.
+
+For IPv6, some devices send AAAA records containing a link-local address.
+The repeater does currently not change such records, meaning that hosts
+might be advertised with unreachable addresses.
 
 
 USAGE
@@ -32,6 +36,7 @@ long as you abide by the software license.
 LICENSE
 --------
 Copyright (C) 2011 Darell Tan
+Copyright (C) 2024 David Härdeman <david@hardeman.nu>
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License

--- a/list.h
+++ b/list.h
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * This is the doubly linked list implementation taken from the Linux
+ * kernel (26 June 2020).
+ *
+ * The only modifications are the ones necessary to make it compile
+ * outside the kernel tree, and to remove some functions which are not
+ * necessary (like hlist*).
+ */
+
+#ifndef _LINUX_LIST_H
+#define _LINUX_LIST_H
+
+struct list_head {
+	struct list_head *next, *prev;
+};
+
+#define offsetof(TYPE, MEMBER) ((size_t) & ((TYPE *)0)->MEMBER)
+
+#define container_of(ptr, type, member)                                        \
+	__extension__({                                                        \
+		const typeof(((type *)0)->member) *__mptr = (ptr);             \
+		(type *)((char *)__mptr - offsetof(type, member));             \
+	})
+
+/*
+ * Simple doubly linked list implementation.
+ *
+ * Some of the internal functions ("__xxx") are useful when
+ * manipulating whole lists rather than single entries, as
+ * sometimes we already know the next/prev entries and we can
+ * generate better code by using them directly rather than
+ * using the generic single-entry routines.
+ */
+
+#define LIST_HEAD_INIT(name)                                                   \
+	{                                                                      \
+		&(name), &(name)                                               \
+	}
+
+#define LIST_HEAD(name) struct list_head name = LIST_HEAD_INIT(name)
+
+/**
+ * INIT_LIST_HEAD - Initialize a list_head structure
+ * @list: list_head structure to be initialized.
+ *
+ * Initializes the list_head to point to itself.  If it is a list header,
+ * the result is an empty list.
+ */
+static inline void INIT_LIST_HEAD(struct list_head *list)
+{
+	list->next = list;
+	list->prev = list;
+}
+
+/*
+ * Insert a new entry between two known consecutive entries.
+ *
+ * This is only for internal list manipulation where we know
+ * the prev/next entries already!
+ */
+static inline void __list_add(struct list_head *new, struct list_head *prev,
+			      struct list_head *next)
+{
+	next->prev = new;
+	new->next = next;
+	new->prev = prev;
+	prev->next = new;
+}
+
+/**
+ * list_add - add a new entry
+ * @new: new entry to be added
+ * @head: list head to add it after
+ *
+ * Insert a new entry after the specified head.
+ * This is good for implementing stacks.
+ */
+static inline void list_add(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head, head->next);
+}
+
+/**
+ * list_del - deletes entry from list.
+ * @entry: the element to delete from the list.
+ * Note: list_empty() on entry does not return true after this, the entry is
+ * in an undefined state.
+ */
+static inline void list_del(struct list_head *entry)
+{
+	entry->next->prev = entry->prev;
+	entry->prev->next = entry->next;
+}
+
+/**
+ * list_empty - tests whether a list is empty
+ * @head: the list to test.
+ */
+static inline int list_empty(const struct list_head *head)
+{
+	return head->next == head;
+}
+
+/**
+ * list_entry - get the struct for this entry
+ * @ptr:	the &struct list_head pointer.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_entry(ptr, type, member) container_of(ptr, type, member)
+
+/**
+ * list_first_entry - get the first element from a list
+ * @ptr:	the list head to take the element from.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_head within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_first_entry(ptr, type, member)                                    \
+	list_entry((ptr)->next, type, member)
+
+/**
+ * list_next_entry - get the next element in list
+ * @pos:	the type * to cursor
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_next_entry(pos, member)                                           \
+	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/**
+ * list_for_each_entry	-	iterate over list of given type
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_for_each_entry(pos, head, member)                                 \
+	for (pos = list_first_entry(head, typeof(*pos), member);               \
+	     &pos->member != (head); pos = list_next_entry(pos, member))
+
+/**
+ * list_for_each_entry_safe - iterate over list of given type safe against
+ * removal of list entry
+ * @pos:	the type * to use as a loop cursor.
+ * @n:		another type * to use as temporary storage
+ * @head:	the head for your list.
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_for_each_entry_safe(pos, n, head, member)                         \
+	for (pos = list_first_entry(head, typeof(*pos), member),               \
+	    n = list_next_entry(pos, member);                                  \
+	     &pos->member != (head); pos = n, n = list_next_entry(n, member))
+
+#endif

--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -226,6 +226,13 @@ create_recv_sock6() {
 	}
 	sock->sockfd = sd;
 
+	// make sure that the socket uses only IPv6
+	if (setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) < 0) {
+		log_message(LOG_ERR, "send setsockopt(IPV6_V6ONLY): %s", strerror(errno));
+		goto out;
+	}
+
+	// make sure that the address can be used by other applications
 	if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
 		log_message(LOG_ERR, "recv setsockopt6(SO_REUSEADDR): %s", strerror(errno));
 		goto out;
@@ -233,11 +240,11 @@ create_recv_sock6() {
 
 	// enable loopback in case someone else needs the data
 	if (setsockopt(sd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &on, sizeof(on)) < 0) {
-		log_message(LOG_ERR, "recv setsockopt6(IP_MULTICAST_LOOP): %s", strerror(errno));
+		log_message(LOG_ERR, "recv setsockopt(IPV6_MULTICAST_LOOP): %s", strerror(errno));
 		goto out;
 	}
 
-	/* bind to an address */
+	// bind to an address
 	memset(&sock->addr, 0, sizeof(sock->addr));
 	sock->addr_in6.sin6_family = AF_INET6;
 	sock->addr_in6.sin6_port = htons(MDNS_PORT);
@@ -273,12 +280,13 @@ create_recv_sock4() {
 	}
 	sock->sockfd = sd;
 
+	// make sure that the address can be used by other applications
 	if (setsockopt(sd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
 		log_message(LOG_ERR, "recv setsockopt(SO_REUSEADDR): %s", strerror(errno));
 		goto out;
 	}
 
-	/* bind to an address */
+	// bind to an address
 	memset(&sock->addr, 0, sizeof(sock->addr));
 	sock->addr_in.sin_family = AF_INET;
 	sock->addr_in.sin_port = htons(MDNS_PORT);

--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -950,9 +950,8 @@ repeat_packet4(struct recv_sock *recv_sock) {
 
 	list_for_each_entry(send_sock, &send_socks4, list) {
 		// make sure packet originated from specified networks
-		if ((recv_sock->from.sin.sin_addr.s_addr & send_sock->am.mask.in.s_addr) == send_sock->am.net.in.s_addr) {
+		if (same_network(&recv_sock->from, &send_sock->am))
 			our_net = true;
-		}
 
 		// check for loopback
 		if (recv_sock->from.sin.sin_addr.s_addr == send_sock->am.addr.sin.sin_addr.s_addr)
@@ -982,7 +981,7 @@ repeat_packet4(struct recv_sock *recv_sock) {
 
 	list_for_each_entry(send_sock, &send_socks4, list) {
 		// do not repeat packet back to the same network from which it originated
-		if ((recv_sock->from.sin.sin_addr.s_addr & send_sock->am.mask.in.s_addr) == send_sock->am.net.in.s_addr)
+		if (same_network(&recv_sock->from, &send_sock->am))
 			continue;
 
 		if (foreground)


### PR DESCRIPTION
This PR adds IPv6 support to mdns-repeater.

I've broken it out into a long list of patches which kind of track the history of rewriting the daemon. In the process I've removed some hardcoded limitations (like the number of interfaces).

I realise that it might be a bit difficult to review the individual patches. It might be better to just read through `mdns-repeater.c` with the whole patchset applied.