### PR TITLE
Define HGVERSION to silence IDE warning

### DIFF
--- a/mdns-repeater.c
+++ b/mdns-repeater.c
@@ -46,6 +46,10 @@
 #define MAX_SOCKS 16
 #define MAX_SUBNETS 16
 
+#ifndef HGVERSION
+#define HGVERSION "unknown"
+#endif
+
 struct if_sock {
 	const char *ifname;	/* interface name  */
 	int sockfd;		/* socket filedesc */


### PR DESCRIPTION
Hi there! I hope the unsolicited PR is okay; please close if not.

When opening the file in vscode, clangd highlights the following "error" in the code as it doesn't gather that `HGVERSION` is inserted in `Makefile`:

```console
Expected ')'clang(expected)
	mdns-repeater.c(339, 9): To match this '('
```

This PR fixes that, if it's something you feel is worth adding.